### PR TITLE
Remove common/index.ts

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,2 +1,0 @@
-export * as Core from './core';
-export * as Types from './types';


### PR DESCRIPTION
Deleted exports for 'Core' and 'Types' from index.ts as they were no longer in use. This helps streamline the code and eliminate unnecessary references.